### PR TITLE
Fix compilation with newer GHCs

### DIFF
--- a/Tools/TimePlot.hs
+++ b/Tools/TimePlot.hs
@@ -19,7 +19,7 @@ import Data.Char
 import Text.Regex.TDFA
 import Text.Regex.TDFA.ByteString
 
-import System
+import System.Environment
 import System.Exit
 import System.Console.GetOpt
 

--- a/timeplot.cabal
+++ b/timeplot.cabal
@@ -29,5 +29,5 @@ executable tplot
     build-depends: Chart >=0.14, base >=3 && <5, bytestring -any,
                    bytestring-lexing -any, cairo -any, colour -any, containers -any,
                    data-accessor ==0.2.*, data-accessor-template >=0.2.1.1 && <0.3,
-                   haskell98 -any, regex-tdfa -any, strptime >=0.1.7, time -any,
+                   regex-tdfa -any, strptime >=0.1.7, time -any,
                    transformers -any


### PR DESCRIPTION
Depending on `base` and `haskell98` packages has become mutually exclusive
