### PR TITLE
Minor color change

### DIFF
--- a/Tools/TimePlot/Plots.hs
+++ b/Tools/TimePlot/Plots.hs
@@ -60,7 +60,7 @@ plotTrackBars vals titles name colors = PlotBarsData {
         barsValues = vals,
         barsStyles = [(solidFillStyle c, Nothing) 
                      |(i,_) <- [0..]`zip`titles 
-                     | c <- transparent:map opaque colors],
+                     | c <- map opaque colors],
         barsTitles = titles
     }
 


### PR DESCRIPTION
Removed transparent colour from barStyles list comprehension.  Fully transparent colours can be non-intuitive in this plot style.  A subjective change, but looks marginally nicer.
