### PR TITLE
Issue #14: Add build constraint to avoid Chart-1.1

### DIFF
--- a/timeplot.cabal
+++ b/timeplot.cabal
@@ -29,7 +29,7 @@ executable tplot
     buildable: True
     ghc-options: -rtsopts
     other-modules: Graphics.Rendering.Chart.Event
-    build-depends: Chart == 1.*, Chart-cairo == 1.*, base >=3 && <5, bytestring -any,
+    build-depends: Chart >= 1.0 && < 1.1, Chart-cairo == 1.*, base >=3 && <5, bytestring -any,
                    bytestring-lexing -any, cairo -any, colour -any, containers -any,
                    data-default -any, lens >= 3.9,
                    regex-tdfa -any, strptime >=0.1.7, time -any,


### PR DESCRIPTION
This is of course just a workaround.
