### PR TITLE
Fix deprecated functions/cabal warnings

### DIFF
--- a/Tools/TimePlot/Plots.hs
+++ b/Tools/TimePlot/Plots.hs
@@ -9,6 +9,7 @@ import Control.Applicative
 import Data.List (foldl', sort)
 import Data.Maybe
 import qualified Data.Map as M
+import qualified Data.Map.Strict as MS
 import qualified Data.Set as Set
 import qualified Data.ByteString.Char8 as S
 
@@ -271,7 +272,7 @@ edges2binsSummary binSize tMin tMax = I.stateful (M.empty, iterate (add binSize)
     --  * r  = reversed list of results per bins
     modState s t (!m, ts,r) f = (m', ts, r)
       where
-        m' = M.insertWith' (\new !old -> f old) s (f (0,t,0,0)) m
+        m' = MS.insertWith (\new !old -> f old) s (f (0,t,0,0)) m
 
     flushBin st@(m,t1:t2:ts,!r) = (m', t2:ts, r')
       where

--- a/timeplot.cabal
+++ b/timeplot.cabal
@@ -23,9 +23,9 @@ source-repository head
 
 executable tplot
     main-is: Tools/TimePlot.hs
-    other-modules: Tools.TimePlot.Conf Tools.TimePlot.Incremental 
-                   Tools.TimePlot.Plots Tools.TimePlot.Render Tools.TimePlot.Source 
-                   Tools.TimePlot.Types
+    other-modules: Tools.TimePlot.Conf Tools.TimePlot.Incremental
+                   Tools.TimePlot.Plots Tools.TimePlot.Render Tools.TimePlot.Source
+                   Tools.TimePlot.Types Paths_timeplot
     buildable: True
     ghc-options: -rtsopts
     other-modules: Graphics.Rendering.Chart.Event


### PR DESCRIPTION
I know that this repository hasn't been updated in a while, but during a migration to NixOS 19.03 I've found this package to be broken. This PR fixes the errors.

It concerns the following warning and error:

```
<no location info>: warning: [-Wmissing-home-modules]
    These modules are needed for compilation but not listed in your .cabal file's other-modules:
        Paths_timeplot
```

```
Tools/TimePlot/Plots.hs:274:14: error:
    • Data.Map.insertWith' is gone. Use Data.Map.Strict.insertWith.
    • In the expression:
        M.insertWith' (\ new !old -> f old) s (f (0, t, 0, 0)) m
      In an equation for ‘m'’:
          m' = M.insertWith' (\ new !old -> f old) s (f (0, t, 0, 0)) m
      In an equation for ‘modState’:
          modState s t (!m, ts, r) f
            = (m', ts, r)
            where
                m' = M.insertWith' (\ new !old -> f old) s (f (0, t, 0, 0)) m
    |
274 |         m' = M.insertWith' (\new !old -> f old) s (f (0,t,0,0)) m
    | 
```

Given the simplicity of the fixes I haven't tested the output.